### PR TITLE
allow multiple connections to different hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,20 +27,20 @@
   },
   "homepage": "https://github.com/blogfoster/hapi-sequelize-models#readme",
   "dependencies": {
-    "joi": "^8.1.1"
+    "joi": "^8.4.2"
   },
   "devDependencies": {
-    "babel-cli": "^6.9.0",
-    "babel-core": "^6.9.0",
+    "babel-cli": "^6.10.1",
+    "babel-core": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
-    "eslint": "^2.10.2",
-    "eslint-config-blogfoster": "^1.3.1",
+    "eslint": "^2.13.1",
+    "eslint-config-blogfoster": "^1.3.2",
     "expect": "^1.20.1",
     "hapi": "^13.4.1",
     "isparta": "^4.0.0",
     "mocha": "^2.5.3",
-    "sequelize": "^3.23.2",
+    "sequelize": "^3.23.3",
     "sqlite3": "^3.1.4"
   },
   "files": [

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -6,31 +6,75 @@ import Sequelize from 'sequelize';
 import HapiSequelizeModels from '../../source';
 
 describe('[integration/plugin]', function () {
-  describe('with missing Sequelize dependency', function () {
-    let server;
-    let error;
-
-    before('create a hapi server', function () {
-      server = new Hapi.Server();
-      server.connection({ host: '127.0.0.1', port: 8080 });
-      return server.register([
-        // hapi-sequelize-models plugin integration
-        {
-          register: HapiSequelizeModels,
-          options: {
-            // without sequelize dependency
-            username: 'test',
-            password: 'test'
-          }
+  describe('wrong configuration', function () {
+    const tests = [
+      {
+        description: 'without `Sequelize`',
+        options: {}
+      },
+      {
+        description: 'without `modelsPath`',
+        options: {
+          Sequelize,
+          connections: [ {
+            database: 'test'
+          } ]
         }
-      ])
-      .catch((err) => {
-        error = err;
-      });
-    });
+      },
+      {
+        description: 'without `database`',
+        options: {
+          Sequelize,
+          connections: [ {
+            modelsPath: '.'
+          } ]
+        }
+      },
+      {
+        description: 'with the same connection defined multiple times',
+        options: {
+          Sequelize,
+          connections: [
+            { modelsPath: '.', database: 'test' },
+            { modelsPath: '.', database: 'test' }
+          ]
+        }
+      },
+      {
+        description: 'with the same model name defined multiple times',
+        options: {
+          Sequelize,
+          connections: [
+            { modelsPath: '.', database: 'test1', models: [ 'test' ] },
+            { modelsPath: '.', database: 'test2', models: [ 'test' ] }
+          ]
+        }
+      }
+    ];
 
-    it('should fail to init the plugin', function () {
-      expect(error).toExist();
+    tests.forEach((test) => {
+      describe(test.description, function () {
+        let server;
+        let error;
+
+        before('create a hapi server', function () {
+          server = new Hapi.Server();
+          server.connection({ host: '127.0.0.1', port: 8080 });
+          return server.register([
+            {
+              register: HapiSequelizeModels,
+              options: test.options
+            }
+          ])
+          .catch((err) => {
+            error = err;
+          });
+        });
+
+        it('should fail to init the plugin', function () {
+          expect(error).toExist();
+        });
+      });
     });
   });
 
@@ -40,26 +84,37 @@ describe('[integration/plugin]', function () {
     before('create a hapi server', function () {
       server = new Hapi.Server();
       server.connection({ host: '127.0.0.1', port: 8080 });
+
+      const config1 = {
+        options: { storage: './test.db', dialect: 'sqlite' },
+        modelsPath: Path.join(__dirname, '../models')
+      };
+
+      const config2 = {
+        options: { storage: './test2.db', dialect: 'sqlite' },
+        modelsPath: Path.join(__dirname, '../models')
+      };
+
       return server.register([
-        // hapi-sequelize-models plugin integration
         {
           register: HapiSequelizeModels,
           options: {
             Sequelize,
-            username: 'test',
-            options: {
-              storage: './test.db',
-              dialect: 'sqlite'
-            },
-            modelsPath: Path.join(__dirname, '../models'),
-            databases: [
+            connections: [
               {
+                ...config1,
                 database: 'test',
                 models: [ 'test', 'test2' ]
               },
               {
+                ...config1,
                 database: 'test2',
                 models: [ 'xxx' ]
+              },
+              {
+                ...config2,
+                database: 'test3',
+                models: [ 'next' ]
               }
             ]
           }
@@ -86,6 +141,7 @@ describe('[integration/plugin]', function () {
         expect(models.test).toExist();
         expect(models.test2).toExist();
         expect(models.xxx).toExist();
+        expect(models.next).toExist();
       });
 
       it('should load Sequelize.Models', function () {
@@ -94,13 +150,19 @@ describe('[integration/plugin]', function () {
         expect(models.test).toBeA(Sequelize.Model);
         expect(models.test2).toBeA(Sequelize.Model);
         expect(models.xxx).toBeA(Sequelize.Model);
+        expect(models.next).toBeA(Sequelize.Model);
       });
 
-      it('should attach an `connection` function to each model, to get the sequelize connection', function () {
+      it('should attach a `connection` function to each model, that returns the sequelize connection', function () {
         const { models } = server.plugins['hapi-sequelize-models'];
 
-        expect(typeof models.test.connection).toEqual('function');
-        expect(models.test.connection()).toExist();
+        Object.keys(models).forEach((name) => {
+          const model = models[name];
+
+          expect(model.connection).toBeA('function');
+          expect(model.connection()).toExist();
+          expect(model.connection()).toBeA(Sequelize);
+        });
       });
     });
   });

--- a/test/models/next.js
+++ b/test/models/next.js
@@ -1,0 +1,17 @@
+/* eslint new-cap: 0 */
+
+export default function defineNext(sequelize, DataTypes) {
+  return sequelize.define('Next', {
+    id: {
+      type: DataTypes.INTEGER(11).UNSIGNED,
+      primaryKey: true,
+      allowNull: false,
+      autoIncrement: true
+    }
+  }, {
+    tableName: 'next',
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+}


### PR DESCRIPTION
This PR will change the setup, so that multiple connections to different hosts will be allowed.
##### changes
- **[major]** introduce `connections` option to define multiple sequelize backend connections
