### PR TITLE
Improve the way models are imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 [![travis-develop][004]][005]
 [![npm-dependencies][006]][007]
 
-This is a Hapi plugin to load your sequelize models. Your models should be defined so that
-[they can be imported by sequelize][001]. The plugin itself will not require `Sequelize`,
-instead you have to pass it in as an option.
+This is a Hapi plugin to load your sequelize models.
 
 
 ## usage
@@ -22,8 +20,7 @@ const mysqlConfig = {
   options: {
     host: process.env.MYSQL_HOST,
     dialect: 'mysql'
-  },
-  modelsPath: Path.join(__dirname, '../models')
+  }
 };
 
 return server.register({
@@ -34,12 +31,26 @@ return server.register({
       {
         ...mysqlConfig,
         database: 'test',
-        models: ['test', 'test2']
+        models: [
+          {
+            name: 'test',
+            model: require('../models/test')
+          },
+          {
+            name: 'test2',
+            model: require('../models/test2')
+          }
+        ]
       },
       {
         ...mysqlConfig,
         database: 'test2',
-        models: ['xxx']
+        models: [
+          {
+            name: 'xxx',
+            model: require('../models/xxx')
+          }
+        ]
       }
     ]
   }
@@ -76,17 +87,16 @@ const handler = {
         - `[host]` - *optional* database host
         - `[dialect]` - *optional* database dialect
         - `[logging = (...msg) => server.log(['trace'], ...mgs)]` - *optional* logging function
-    - `modelsPath` - path to your model definitions
-    - `[models = []]` - *optional* list of models that should be loaded
-        - `[*]` - *(String)* model names; models must be located at `<modelsPath>/<modelName>`
+    - `[models]` - list of objects with the following properties:
+        - `name` - name of the model
+        - `model` - the model definition to load with sequelize
 
 ## model definition
 
 Models should be defined so that they can be imported using [sequelize.import][001]. For convenience
 a `.connection()` function is attached to each model, to access its underlaying sequelize connection.
 
-Also models will be availabe using `server.plugins['hapi-sequelize-models'].models.<modelName>`. Here `<modelName>`
-is not the name defined in `sequelize.define`, but the filename, which is also used in the `databases[*].models[*]`.
+Also models will be available using `server.plugins['hapi-sequelize-models'].models.<modelName>`.
 
 ```javascript
 const handler = {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![travis-develop][004]][005]
 [![npm-dependencies][006]][007]
 
-This is a Hapi plugin to load your sequelize models.
+This is a Hapi plugin to load your sequelize models. Your models should be defined so that
+[they can be imported by sequelize][001]. The plugin itself will not require `Sequelize`,
+instead you have to pass it in as an option.
 
 
 ## usage
@@ -96,7 +98,7 @@ const handler = {
 Models should be defined so that they can be imported using [sequelize.import][001]. For convenience
 a `.connection()` function is attached to each model, to access its underlaying sequelize connection.
 
-Also models will be available using `server.plugins['hapi-sequelize-models'].models.<modelName>`.
+Also models will be available using `server.plugins['hapi-sequelize-models'].models.<name>` where `<name>` is the name of the model specified in the config.
 
 ```javascript
 const handler = {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
     "eslint": "^2.13.1",
-    "eslint-config-blogfoster": "^1.3.2",
+    "eslint-config-blogfoster": "~1.3.2",
     "expect": "^1.20.1",
     "hapi": "^13.4.1",
     "isparta": "^4.0.0",

--- a/source/index.js
+++ b/source/index.js
@@ -20,7 +20,7 @@ const ConfigSchema = Joi.object().keys({
           name: Joi.string()
             .required()
             .description('name of the model'),
-          model: Joi.object()
+          model: Joi.func()
             .required()
             .description('the model that should be imported by sequelize')
         }),

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,9 +1,9 @@
 import expect from 'expect';
 import Hapi from 'hapi';
-import Path from 'path';
 import Sequelize from 'sequelize';
 
 import HapiSequelizeModels from '../../source';
+import models from '../models';
 
 describe('[integration/plugin]', function () {
   describe('wrong configuration', function () {
@@ -13,21 +13,10 @@ describe('[integration/plugin]', function () {
         options: {}
       },
       {
-        description: 'without `modelsPath`',
-        options: {
-          Sequelize,
-          connections: [ {
-            database: 'test'
-          } ]
-        }
-      },
-      {
         description: 'without `database`',
         options: {
           Sequelize,
-          connections: [ {
-            modelsPath: '.'
-          } ]
+          connections: [ {} ]
         }
       },
       {
@@ -35,8 +24,8 @@ describe('[integration/plugin]', function () {
         options: {
           Sequelize,
           connections: [
-            { modelsPath: '.', database: 'test' },
-            { modelsPath: '.', database: 'test' }
+            { database: 'test' },
+            { database: 'test' }
           ]
         }
       },
@@ -45,8 +34,8 @@ describe('[integration/plugin]', function () {
         options: {
           Sequelize,
           connections: [
-            { modelsPath: '.', database: 'test1', models: [ 'test' ] },
-            { modelsPath: '.', database: 'test2', models: [ 'test' ] }
+            { database: 'test1', models: [ { name: 'test', model: models.test } ] },
+            { database: 'test2', models: [ { name: 'test', model: models.test } ] }
           ]
         }
       }
@@ -85,15 +74,8 @@ describe('[integration/plugin]', function () {
       server = new Hapi.Server();
       server.connection({ host: '127.0.0.1', port: 8080 });
 
-      const config1 = {
-        options: { storage: './test.db', dialect: 'sqlite' },
-        modelsPath: Path.join(__dirname, '../models')
-      };
-
-      const config2 = {
-        options: { storage: './test2.db', dialect: 'sqlite' },
-        modelsPath: Path.join(__dirname, '../models')
-      };
+      const config1 = { options: { storage: './test.db', dialect: 'sqlite' } };
+      const config2 = { options: { storage: './test2.db', dialect: 'sqlite' } };
 
       return server.register([
         {
@@ -104,17 +86,36 @@ describe('[integration/plugin]', function () {
               {
                 ...config1,
                 database: 'test',
-                models: [ 'test', 'test2' ]
+                models: [
+                  {
+                    name: 'test',
+                    model: models.test
+                  },
+                  {
+                    name: 'test2',
+                    model: models.test2
+                  }
+                ]
               },
               {
                 ...config1,
                 database: 'test2',
-                models: [ 'xxx' ]
+                models: [
+                  {
+                    name: 'xxx',
+                    model: models.xxx
+                  }
+                ]
               },
               {
                 ...config2,
                 database: 'test3',
-                models: [ 'next' ]
+                models: [
+                  {
+                    name: 'next',
+                    model: models.next
+                  }
+                ]
               }
             ]
           }

--- a/test/models/index.js
+++ b/test/models/index.js
@@ -1,0 +1,11 @@
+import next from './next';
+import test from './test';
+import test2 from './test2';
+import xxx from './xxx';
+
+export default {
+  next,
+  test,
+  test2,
+  xxx
+};


### PR DESCRIPTION
Fixes #5 

- Requires models to be part of the dependency tree
- Fixes issues with module bundlers and use-cases where `babel-register` is not used

From the commit message:

> BREAKING CHANGE
> This changes the schema of the configs passed into the plugin.
> From now on models are no longer defined via paths but should be
> directly part of the config.
>
> - `modelsPath` has been removed
> - `models` is now an array of objects where each object must have
>  two properties:
>  - `name` which is the name of the model that should be imported
>  - `model` which contains the sequelize model